### PR TITLE
Updated fetchData with no initial user preferences

### DIFF
--- a/common-components/CHANGELOG.md
+++ b/common-components/CHANGELOG.md
@@ -7,7 +7,8 @@ All changes to this project will be documented in this file.
 ## [0.0.11] - 01-04-2025
 
 - Updated preference page loading
-- 
+- Updated date formating for ended chats to hold only date without time.
+
 ## [0.0.10] - 14-04-2025
 
 - Changed dialog visibility

--- a/common-components/CHANGELOG.md
+++ b/common-components/CHANGELOG.md
@@ -4,6 +4,10 @@ All changes to this project will be documented in this file.
 
 ## Template [MajorVersion.MediterraneanVersion.MinorVersion] - DD-MM-YYYY
 
+## [0.0.10] - 01-04-2025
+
+- Updated preference page loading
+
 ## [0.0.9] - 01-04-2025
 
 - Prevent end-users from spoofing URLs in messages

--- a/common-components/package.json
+++ b/common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/common-gui-components",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Common GUI components and pre defined templates.",
   "main": "index.ts",
   "author": "ExiRai",

--- a/common-components/package.json
+++ b/common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/common-gui-components",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Common GUI components and pre defined templates.",
   "main": "index.ts",
   "author": "ExiRai",

--- a/common-components/templates/history-page/src/index.tsx
+++ b/common-components/templates/history-page/src/index.tsx
@@ -131,12 +131,17 @@ const ChatHistory: FC<PropsWithChildren<HistoryProps>> = ({user, toastContext, o
                     page_name: window.location.pathname,
                 },
             });
-            if (response.data.pageResults !== undefined) {
-                const newSelectedColumns = response.data?.selectedColumns.length === 1 && response.data?.selectedColumns[0] === "" ? [] : response.data?.selectedColumns;
+            if (response.data) {
+                const currentColumns = response.data.selectedColumns;
+                const newPageResults = response.data.pageResults !== undefined ? response.data.pageResults : 10;
+                const updatedPagination = updatePagePreference(newPageResults);
+
+                let newSelectedColumns = [];
+                if(currentColumns !== undefined && currentColumns.length > 0 && currentColumns[0] !== "") {
+                    newSelectedColumns = currentColumns;
+                }
                 setSelectedColumns(newSelectedColumns)
-                const updatedPagination = updatePagePreference(
-                    response.data.pageResults ?? 10
-                );
+
                 setCounterKey(counterKey + 1)
                 getAllEndedChats.mutate({
                     startDate: format(new Date(startDate), 'yyyy-MM-dd'),
@@ -148,7 +153,7 @@ const ChatHistory: FC<PropsWithChildren<HistoryProps>> = ({user, toastContext, o
                 });
             }
         } catch (err) {
-            console.error('Failed to fetch data');
+            console.error('Failed to fetch data', err);
         }
     };
 

--- a/common-components/templates/history-page/src/index.tsx
+++ b/common-components/templates/history-page/src/index.tsx
@@ -216,8 +216,8 @@ const ChatHistory: FC<PropsWithChildren<HistoryProps>> = ({user, toastContext, o
 
             return apiDev.post('agents/chats/ended', {
                 customerSupportIds: data.customerSupportIds,
-                startDate: data.startDate,
-                endDate: data.endDate,
+                startDate: format(new Date(data.startDate), 'yyyy-MM-dd'),
+                endDate: format(new Date(data.endDate), 'yyyy-MM-dd'),
                 page: data.pagination.pageIndex + 1,
                 page_size: data.pagination.pageSize,
                 sorting: sortBy,


### PR DESCRIPTION
- Updated fetchData method for history template, to work better when data is not provided
- Updated date passing so ended chat would use date without time

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1208).
Relate [task 2](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1297).