### PR TITLE
Display feedback rating consistently in history page

### DIFF
--- a/common-components/CHANGELOG.md
+++ b/common-components/CHANGELOG.md
@@ -4,9 +4,13 @@ All changes to this project will be documented in this file.
 
 ## Template [MajorVersion.MediterraneanVersion.MinorVersion] - DD-MM-YYYY
 
-## [0.0.14] - 02-05-2025
+## [0.0.15] - 09-05-2025
 
 - Display feedback rating consistently in history page.
+
+## [0.0.14] - 05-05-2025
+
+- Updated popup duration to be 5 seconds.
 
 ## [0.0.13] - 25-04-2025
 

--- a/common-components/CHANGELOG.md
+++ b/common-components/CHANGELOG.md
@@ -4,6 +4,10 @@ All changes to this project will be documented in this file.
 
 ## Template [MajorVersion.MediterraneanVersion.MinorVersion] - DD-MM-YYYY
 
+## [0.0.14] - 02-05-2025
+
+- Display feedback rating consistently in history page.
+
 ## [0.0.13] - 25-04-2025
 
 - Adding double scrollbar to history page when size is small.

--- a/common-components/package.json
+++ b/common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/common-gui-components",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Common GUI components and pre defined templates.",
   "main": "index.ts",
   "author": "ExiRai",

--- a/common-components/templates/history-page/src/index.tsx
+++ b/common-components/templates/history-page/src/index.tsx
@@ -514,8 +514,10 @@ const ChatHistory: FC<PropsWithChildren<HistoryProps>> = ({user, toastContext, o
             columnHelper.accessor('feedbackRating', {
                 id: 'feedbackRating',
                 header: t('chat.history.rating') ?? '',
-                cell: (props) =>
-                    props.getValue() && <span>{`${props.getValue()}/10`}</span>,
+                cell: (props) => {
+                    const value = props.getValue();
+                    return value !== null && value !== undefined ? <span>{`${value}/10`}</span> : null;
+                }
             }),
             columnHelper.accessor('feedbackText', {
                 id: 'feedbackText',


### PR DESCRIPTION
Display feedback rating consistently in history page.
This PR is related to issue https://github.com/buerokratt/Buerokratt-Chatbot/issues/1318