### PR TITLE
965 History page, screen space

### DIFF
--- a/common-components/CHANGELOG.md
+++ b/common-components/CHANGELOG.md
@@ -4,6 +4,10 @@ All changes to this project will be documented in this file.
 
 ## Template [MajorVersion.MediterraneanVersion.MinorVersion] - DD-MM-YYYY
 
+## [0.0.20] - 21-05-2025
+
+- Making chat view go take all vertical space.
+
 ## [0.0.19] - 19-05-2025
 
 - Reduced extra calling of mutation on init.

--- a/common-components/package.json
+++ b/common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/common-gui-components",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Common GUI components and pre defined templates.",
   "main": "index.ts",
   "author": "ExiRai",

--- a/common-components/templates/history-page/src/index.tsx
+++ b/common-components/templates/history-page/src/index.tsx
@@ -886,7 +886,7 @@ const ChatHistory: FC<PropsWithChildren<HistoryProps>> = ({
                     </Button>
                 </div>)
             }
-            <div className="card-drawer-container" style={{ height: 'auto', overflow: 'auto' }}>
+            <div className="card-drawer-container" style={{ height: '100%', overflow: 'auto' }}>
                 <div className="card-wrapper">
                     <Card>
                         <DataTable


### PR DESCRIPTION
- Updated to version 0.0.20
- Chat view takes 100% of available vertical space.

Related [task](https://github.com/buerokratt/Training-Module/issues/965).