### PR TITLE
Initial support for Multidomains in history page.

### DIFF
--- a/common-components/CHANGELOG.md
+++ b/common-components/CHANGELOG.md
@@ -4,6 +4,13 @@ All changes to this project will be documented in this file.
 
 ## Template [MajorVersion.MediterraneanVersion.MinorVersion] - DD-MM-YYYY
 
+## [0.0.23] - 21-07-2025
+
+- Initial support of multidomains
+- Added updated key to force fetching on domain change
+- Updated store params
+- Made store export state for reusability
+
 ## [0.0.22] - 01-07-2025
 
 - Handled Previous Messages Edge Case in Buttons

--- a/common-components/package.json
+++ b/common-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/common-gui-components",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Common GUI components and pre defined templates.",
   "main": "index.ts",
   "author": "ExiRai",

--- a/common-components/store/index.ts
+++ b/common-components/store/index.ts
@@ -8,7 +8,7 @@ import {
 } from '../types/chat';
 import { apiDev } from '../services/api';
 
-interface StoreState {
+export interface StoreState {
     userInfo: UserInfo | null;
     userId: string;
     activeChats: ChatType[];
@@ -31,6 +31,8 @@ interface StoreState {
     getGroupedUnansweredChats: () => GroupedChat;
     loadPendingChats: () => Promise<void>;
     getGroupedPendingChats: () => GroupedPendingChat;
+    userDomains: string[];
+    setUserDomains: (domains: string[]) => void;
 }
 
 const useStore = create<StoreState>((set, get, store) => ({
@@ -38,12 +40,14 @@ const useStore = create<StoreState>((set, get, store) => ({
     userId: '',
     activeChats: [],
     pendingChats: [],
+    userDomains: [],
     selectedChatId: null,
     chatCsaActive: false,
     setActiveChats: (chats) => set({ activeChats: chats }),
     setPendingChats: (chats) => set({ pendingChats: chats }),
     setUserInfo: (data) => set({ userInfo: data, userId: data?.idCode || '' }),
     setSelectedChatId: (id) => set({ selectedChatId: id }),
+    setUserDomains: (data: string[]) => set({ userDomains: data}),
     setChatCsaActive: (active) => {
         set({
             chatCsaActive: active,

--- a/common-components/utils/multiDomain-utils.ts
+++ b/common-components/utils/multiDomain-utils.ts
@@ -1,0 +1,8 @@
+import useStore from "../store";
+
+export const getDomainsArray = (currentDomains) => {
+    const multiDomainEnabled = import.meta.env.REACT_APP_ENABLE_MULTI_DOMAIN.toLowerCase() === 'true';
+    const userDomains = currentDomains || [];
+
+    return multiDomainEnabled ? (userDomains?.length > 0 ? userDomains : [null]) : [];
+}


### PR DESCRIPTION
- Updated package to version 0.23
- Added multidomains to store
- Made storestatde exported for use in template
- Added update key to force refetch on domain update

Related [task](https://github.com/buerokratt/Analytics-Module/issues/496).